### PR TITLE
Fixed weird display in Facebook button

### DIFF
--- a/_sass/theme.scss
+++ b/_sass/theme.scss
@@ -455,7 +455,7 @@ html {
 
 .news-fb > a {
   margin-top: 0;
-  font-size: 1.3rem;
+  font-size: 0.9rem;
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
Text went outside of the button causing a weird display. Update fixes
things.

Making the font smaller resolves the issue.

Fixes issue #5